### PR TITLE
Display User's displayName instead of their identifier

### DIFF
--- a/src/app/advertisement/advertisement.component.html
+++ b/src/app/advertisement/advertisement.component.html
@@ -25,7 +25,7 @@
           </a>
         </div>
         <div class="info">
-          By <a routerLink="/profile/{{advertisement.owner}}">{{advertisement.owner}}</a> on {{advertisement.createdAt | date}}
+          By <a routerLink="/profile/{{advertisement.owner}}">{{users['/users/' + advertisement.owner]?.displayName || '...'}}</a> on {{advertisement.createdAt | date}}
         </div>
         <div class="info-special">
           <a [routerLink]="[advertisement.uri]" class="buy">{{advertisement.price | currency:'USD':true}}</a>

--- a/src/app/advertisement/advertisement.component.spec.ts
+++ b/src/app/advertisement/advertisement.component.spec.ts
@@ -5,6 +5,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { AdvertisementComponent } from './advertisement.component';
 import { AdvertisementService } from './advertisement.service';
 import { SearchAdvertisementService } from './search-advertisement/searchAdvertisement.service';
+import { ProfileService } from '../profile/profile.service';
 import { ActivatedRoute } from '@angular/router';
 
 describe('Component: Advertisement', () => {
@@ -17,16 +18,18 @@ describe('Component: Advertisement', () => {
 
   it('should create an instance', () => {
     inject([
-      ActivatedRoute,
-      AdvertisementService,
-      SearchAdvertisementService
+        ActivatedRoute,
+        AdvertisementService,
+        SearchAdvertisementService,
+        ProfileService,
       ],
       (
         activatedRoute,
         advertisementService,
-        searchAdvertisementService
+        searchAdvertisementService,
+        profileService,
       ) => {
-      let component = new AdvertisementComponent(activatedRoute, advertisementService, searchAdvertisementService);
+      let component = new AdvertisementComponent(activatedRoute, advertisementService, searchAdvertisementService, profileService);
       expect(component).toBeTruthy();
     });
 

--- a/src/app/advertisement/advertisement.component.ts
+++ b/src/app/advertisement/advertisement.component.ts
@@ -2,24 +2,28 @@ import { Component, OnInit } from '@angular/core';
 
 import { Advertisement } from './advertisement';
 import { AdvertisementService } from './advertisement.service';
+import { ProfileService } from '../profile/profile.service';
 import { ActivatedRoute } from '@angular/router';
 import { SearchAdvertisementService } from './search-advertisement/searchAdvertisement.service';
+import UsersCache from '../profile/usersCache';
 
 @Component({
   selector: 'app-advertisement',
   templateUrl: './advertisement.component.html',
   styleUrls: ['./advertisement.component.scss'],
-  providers: [AdvertisementService, SearchAdvertisementService]
+  providers: [AdvertisementService, SearchAdvertisementService, ProfileService]
 })
 export class AdvertisementComponent implements OnInit {
 
   advertisements: Advertisement[];
   advertisementPictures: {} = {};
   errorMessage: string;
+  users = UsersCache.entries();
 
   constructor(private route: ActivatedRoute,
               private advertisementService: AdvertisementService,
-              private searchAdvertisementService: SearchAdvertisementService) { }
+              private searchAdvertisementService: SearchAdvertisementService,
+              private profileService: ProfileService) { }
 
   ngOnInit() {
     this.route.queryParams.subscribe(
@@ -44,6 +48,7 @@ export class AdvertisementComponent implements OnInit {
           this.advertisements = advertisements;
           this.advertisements.map((advertisement) => {
             this.getAdvertisementPicture(advertisement);
+            this.profileService.getUser(`/users/${advertisement.owner}`).subscribe();
           });
         },
         error => this.errorMessage = <any>error.message

--- a/src/app/advertisement/getAdvertisement.component.html
+++ b/src/app/advertisement/getAdvertisement.component.html
@@ -60,7 +60,7 @@
     <div class="col-md-6">
       <div class="row">
         <h3>Owner Info</h3>
-        Published by <a routerLink="/profile/{{advertisement.owner}}">{{advertisement.owner}}</a>
+        Published by <a routerLink="/profile/{{advertisement.owner}}">{{users['/users/' + advertisement.owner]?.displayName || '...'}}</a>
       </div>
     </div>
   </div>

--- a/src/app/advertisement/getAdvertisement.component.spec.ts
+++ b/src/app/advertisement/getAdvertisement.component.spec.ts
@@ -8,6 +8,7 @@ import { GetAdvertisementComponent } from './getAdvertisement.component';
 import { PurchaseService } from '../purchase/purchase.service';
 import { Auth0Service } from '../auth0/auth0.service';
 import { BasketProductService } from '../basketProduct/basketProduct.service';
+import { ProfileService } from '../profile/profile.service';
 
 describe('Component: GetAdvertisement', () => {
   beforeEach(() => {
@@ -17,15 +18,16 @@ describe('Component: GetAdvertisement', () => {
   });
 
   it ('should create an instance', () => {
-    inject([ ActivatedRoute, Router, AdvertisementService, PurchaseService, Auth0Service, BasketProductService ],
-           (activatedRoute, router, advertisementService, purchaseService, auth0Service, basketProductService) => {
+    inject([ ActivatedRoute, Router, AdvertisementService, PurchaseService, Auth0Service, BasketProductService, ProfileService ],
+           (activatedRoute, router, advertisementService, purchaseService, auth0Service, basketProductService, profileService) => {
       let component = new GetAdvertisementComponent(
         activatedRoute,
         router,
         advertisementService,
         purchaseService,
         auth0Service,
-        basketProductService
+        basketProductService,
+        profileService,
       );
       expect(component).toBeTruthy();
     });

--- a/src/app/advertisement/getAdvertisement.component.ts
+++ b/src/app/advertisement/getAdvertisement.component.ts
@@ -7,14 +7,16 @@ import { Picture } from './picture/picture';
 import { Purchase } from '../purchase/purchase';
 import { PurchaseService } from '../purchase/purchase.service';
 import { Auth0Service } from '../auth0/auth0.service';
-import { BasketProductService} from '../basketProduct/basketProduct.service';
-import { BasketProduct} from '../basketProduct/basketProduct';
+import { BasketProductService } from '../basketProduct/basketProduct.service';
+import { BasketProduct } from '../basketProduct/basketProduct';
+import { ProfileService } from '../profile/profile.service';
+import UsersCache from '../profile/usersCache';
 
 @Component({
   selector: 'app-get-advertisement',
   templateUrl: './getAdvertisement.component.html',
   styleUrls: ['./getAdvertisement.component.scss'],
-  providers: [AdvertisementService, PurchaseService]
+  providers: [AdvertisementService, PurchaseService, ProfileService]
 })
 export class GetAdvertisementComponent implements OnInit {
 
@@ -26,12 +28,15 @@ export class GetAdvertisementComponent implements OnInit {
   deleteConfirmText: String = '';
   isDeleting: boolean = false;
 
+  users = UsersCache.entries();
+
   constructor(private route: ActivatedRoute,
               private router: Router,
               private advertisementService: AdvertisementService,
               private purchaseService: PurchaseService,
               private authentication: Auth0Service,
-              private basketProductService: BasketProductService) {
+              private basketProductService: BasketProductService,
+              private profileService: ProfileService) {
   }
   /**
    * On Startup:
@@ -55,6 +60,7 @@ export class GetAdvertisementComponent implements OnInit {
         // The advertisement does exist, let's query the rest.
         this.getAdvertisementPicture(this.advertisement.uri);
         this.getAdvertisementPurchase(this.advertisement.uri);
+        this.profileService.getUser(`/users/${advertisement.owner}`).subscribe();
       },
       error => this.router.navigate(['/404']),
     );

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -32,7 +32,7 @@ export class ProfileComponent implements OnInit {
   }
 
   getUser(uri) {
-    this.profileService.getUser(uri)
+    this.profileService.getUser(uri, false)
       .subscribe(
         user => this.user = user,
         error => this.router.navigate(['/404']),

--- a/src/app/profile/profile.service.spec.ts
+++ b/src/app/profile/profile.service.spec.ts
@@ -1,0 +1,63 @@
+/* tslint:disable:no-unused-variable */
+
+import { TestBed, async, inject, getTestBed } from '@angular/core/testing';
+import { BaseRequestOptions, XHRBackend, Http, HttpModule, ResponseOptions, Response
+} from '@angular/http';
+import { MockBackend, MockConnection } from '@angular/http/testing';
+import { ProfileService } from './profile.service';
+
+describe('Service: Profile', () => {
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        ProfileService,
+        MockBackend,
+        BaseRequestOptions,
+        {
+          provide: Http,
+          deps: [MockBackend, BaseRequestOptions],
+          useFactory: (backend: XHRBackend, defaultOptions: BaseRequestOptions) => {
+            return new Http(backend, defaultOptions);
+          },
+        }
+      ],
+      imports: [HttpModule]
+    });
+  }));
+
+  describe('#getUser()', () => {
+    it('should use UsersCache when retrieving 2n time',
+      async(inject([ MockBackend, ProfileService ], (mockBackend, service) => {
+        const uri = '/users/profile.service.spec.it.1';
+        let mockBackendCalled = 0;
+        mockBackend.connections.subscribe((connection: MockConnection) => {
+          mockBackendCalled++;
+          const response = new ResponseOptions({ body: { uri } });
+          connection.mockRespond(new Response(response));
+        });
+
+        service.getUser(uri).subscribe(() => {
+          service.getUser(uri).subscribe(() => {
+            expect(mockBackendCalled).toBe(1);
+          });
+        });
+    })));
+
+    it('should not use UsersCache if specifically indicated so',
+      async(inject([ MockBackend, ProfileService ], (mockBackend, service) => {
+        const uri = '/users/profile.service.spec.it.2';
+        let mockBackendCalled = 0;
+        mockBackend.connections.subscribe((connection: MockConnection) => {
+          mockBackendCalled++;
+          const response = new ResponseOptions({ body: { uri } });
+          connection.mockRespond(new Response(response));
+        });
+
+        service.getUser(uri).subscribe(() => {
+          service.getUser(uri, false).subscribe(() => {
+            expect(mockBackendCalled).toBe(2);
+          });
+        });
+    })));
+  });
+});

--- a/src/app/profile/profile.service.ts
+++ b/src/app/profile/profile.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { User } from '../auth0/user';
 import { environment } from '../../environments/environment';
 import { Auth0Service } from '../auth0/auth0.service';
+import UsersCache from './usersCache';
 
 @Injectable()
 export class ProfileService {
@@ -13,10 +14,17 @@ export class ProfileService {
   }
 
   // GET /users/<username>
-  getUser(uri: string): Observable<User> {
+  getUser(uri: string, useCache: Boolean = true): Observable<User> {
+    if (useCache && uri in UsersCache.entries()) {
+      return Observable.of(UsersCache.entries()[uri]);
+    }
+
     return this.http.get(`${environment.API}${uri}`)
-      .map((res: Response) => {
-        return new User(res.json());
+      .map((res: Response) => res.json())
+      .map((userResult: User) => {
+        const user = new User(userResult);
+        UsersCache.add(user);
+        return new User(user);
       })
       .catch((error: any) => Observable.throw(error.json()));
   }

--- a/src/app/profile/usersCache.ts
+++ b/src/app/profile/usersCache.ts
@@ -1,0 +1,19 @@
+import { User } from '../auth0/user';
+
+class UsersCache {
+  // A cache of users { uri: User }.
+  private db = {};
+
+  /**
+   * Add User to cache. If it already exists replace it.
+   */
+  add(user: User) {
+    this.db[user.uri] = user;
+  }
+
+  entries(): {} {
+    return this.db;
+  }
+}
+
+export default new UsersCache();

--- a/src/app/purchase/purchase.component.html
+++ b/src/app/purchase/purchase.component.html
@@ -27,7 +27,7 @@
       <tr *ngFor="let advertisement of advertisements">
         <td>{{advertisement.id}}</td>
         <td><a routerLink="/advertisements/{{advertisement.id}}">{{advertisement.title}}</a></td>
-        <td><a routerLink="/profile/{{advertisement.owner}}">{{advertisement.owner}}</a></td>
+        <td><a routerLink="/profile/{{advertisement.owner}}">{{users['/users/' + advertisement.owner]?.displayName || '...'}}</a></td>
         <td>{{advertisement.price | currency:'USD':true}}</td>
       </tr>
     </table>

--- a/src/app/purchase/purchase.component.spec.ts
+++ b/src/app/purchase/purchase.component.spec.ts
@@ -1,11 +1,12 @@
 /* tslint:disable:no-unused-variable */
 
 import { TestBed, async, inject } from '@angular/core/testing';
-import {Router, ActivatedRoute} from '@angular/router';
+import { Router, ActivatedRoute } from '@angular/router';
 
 import { PurchaseComponent } from './purchase.component';
 import { PurchaseService } from './purchase.service';
-import {AdvertisementService} from '../advertisement/advertisement.service';
+import { AdvertisementService } from '../advertisement/advertisement.service';
+import { ProfileService } from '../profile/profile.service';
 
 describe('Component: Purchase', () => {
 
@@ -16,12 +17,13 @@ describe('Component: Purchase', () => {
   });
 
   it('should create an instance', () => {
-    inject([ActivatedRoute, AdvertisementService, PurchaseService],
-      (activatedRouter, advertisementService, purchaseService) => {
+    inject([ActivatedRoute, AdvertisementService, PurchaseService, ProfileService],
+      (activatedRouter, advertisementService, purchaseService, profileService) => {
       let component = new PurchaseComponent(
         activatedRouter,
         advertisementService,
-        purchaseService
+        purchaseService,
+        profileService,
       );
       expect(component).toBeTruthy();
   });

--- a/src/app/purchase/purchase.component.ts
+++ b/src/app/purchase/purchase.component.ts
@@ -4,12 +4,14 @@ import { PurchaseService } from './purchase.service';
 import { AdvertisementService } from '../advertisement/advertisement.service';
 import { Advertisement } from '../advertisement/advertisement';
 import { Router, ActivatedRoute } from '@angular/router';
+import { ProfileService } from '../profile/profile.service';
+import UsersCache from '../profile/usersCache';
 
 @Component({
   selector: 'app-purchase',
   templateUrl: './purchase.component.html',
   styleUrls: ['./purchase.component.scss'],
-  providers: [AdvertisementService, PurchaseService],
+  providers: [AdvertisementService, PurchaseService, ProfileService],
 })
 export class PurchaseComponent implements OnInit {
   errorMessage: string;
@@ -21,9 +23,12 @@ export class PurchaseComponent implements OnInit {
   purchase: Purchase; // It will exist either if the product was already
                       // purchased, or the user has just completed the purchase.
 
+  users = UsersCache.entries();
+
   constructor(private route: ActivatedRoute,
                private advertisementService: AdvertisementService,
-               private purchaseService: PurchaseService) {}
+               private purchaseService: PurchaseService,
+               private profileService: ProfileService) {}
 
   ngOnInit() {
     this.route.params
@@ -42,6 +47,7 @@ export class PurchaseComponent implements OnInit {
         this.advertisements.push(advertisement);
 
         this.loadPurchase(advertisement);
+        this.profileService.getUser(`/users/${advertisement.owner}`).subscribe();
       },
       error => this.errorMessage = 'The advertisement does not exist.',
     );


### PR DESCRIPTION
- [UsersCache](https://github.com/UdL-EPS-SoftArch/softarch-1617-client/commit/f14689b9ab56c19860d0faec59f15118abec995f) in-memory storage. An already looked up user will not be requested to the API again, unless strictly specified or the client refreshes the page.
- Advertisement list, individual advertisement and purchase are taking advantage of `UsersCache` to display users `user.displayName` instead of their identifier (`advertisement.owner`).